### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 - The `get_package` method has been added.
+- Update tokio to 1.0
+- Update reqwest to 0.11
+- Update url to 2.2
+- Update bytes to 1.0
 
 ## v1.1.1 - 2020-07-20
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ categories = ["api-bindings"]
 
 [dependencies]
 # HTTP client
-reqwest = { version = "0.10", features = ["json"] }
+reqwest = { version = "0.11", features = ["json"] }
 # Derive Error trait
 thiserror = "1.0"
 # JSON (de)serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # HTTP types
-url = "2.1"
+url = "2.2"
 http = "0.2"
 # Macro to have async fns in traits
 async-trait = "0.1"
@@ -29,7 +29,7 @@ lazy_static = "1.4"
 # Text parsing with regular expressions
 regex = "1.3.7"
 # Byte collections
-bytes = "0.5"
+bytes = "1"
 # Protobuf runtime
 protobuf = "2.3"
 # gzip (de)compression
@@ -43,7 +43,7 @@ x509-parser = "0.8.0-beta4"
 # HTTP mock server
 mockito = "0.25.1"
 # Async runtime
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 
 [build-dependencies]
 # Protobuf code generation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod tests;
 
 use crate::proto::{signed::Signed, versions::Versions};
 use async_trait::async_trait;
-use bytes::buf::ext::BufExt;
+use bytes::buf::Buf;
 use flate2::read::GzDecoder;
 use lazy_static::lazy_static;
 use regex::Regex;


### PR DESCRIPTION
👋 

I was poking around gleam and noticed it wasn't using tokio 1.0 yet. Seems this has to be updated first. Its possible now since a new version of reqwest is out.