### PR TITLE
Bump x509 parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ flate2 = "1.0"
 # RSA signature and SHA256 checksum verification
 ring = "0.16"
 # PEM -> DER conversion
-x509-parser = "0.9"
+x509-parser = "0.15"
 # Pubgrub dependency resolution algorithm
 pubgrub = "0.2"
 # Basic auth HTTP helper

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ use regex::Regex;
 use ring::digest::{Context, SHA256};
 use serde::Deserialize;
 use serde_json::json;
+use x509_parser::prelude::FromDer;
 use std::{collections::HashMap, convert::TryFrom, convert::TryInto, io::BufReader};
 use thiserror::Error;
 use version::{Range, Version};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,6 @@ pub fn get_package_response(
     match parts.status {
         StatusCode::OK => (),
         StatusCode::FORBIDDEN => return Err(ApiError::NotFound), // Oddly this is the not-found code
-        StatusCode::NOT_FOUND => return Err(ApiError::NotFound),
         status => {
             return Err(ApiError::unexpected_response(status, body));
         }
@@ -343,7 +342,6 @@ pub fn get_package_tarball_response(
     match parts.status {
         StatusCode::OK => (),
         StatusCode::FORBIDDEN => return Err(ApiError::NotFound),
-        StatusCode::NOT_FOUND => return Err(ApiError::NotFound),
         status => {
             return Err(ApiError::unexpected_response(status, body));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,7 @@ pub fn get_package_response(
     match parts.status {
         StatusCode::OK => (),
         StatusCode::FORBIDDEN => return Err(ApiError::NotFound), // Oddly this is the not-found code
+        StatusCode::NOT_FOUND => return Err(ApiError::NotFound),
         status => {
             return Err(ApiError::unexpected_response(status, body));
         }
@@ -342,6 +343,7 @@ pub fn get_package_tarball_response(
     match parts.status {
         StatusCode::OK => (),
         StatusCode::FORBIDDEN => return Err(ApiError::NotFound),
+        StatusCode::NOT_FOUND => return Err(ApiError::NotFound),
         status => {
             return Err(ApiError::unexpected_response(status, body));
         }


### PR DESCRIPTION
`x509-parser 0.9` depends on `nom 0.6`, which causes future warnings: 
```
warning: the following packages contain code that will be rejected by a future version of Rust: nom v6.1.2
```
in [gleam lang repo](https://github.com/gleam-lang/gleam), so updgrade that version.