### PR TITLE
fix unexpected error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@ pub fn get_package_response(
 
     match parts.status {
         StatusCode::OK => (),
-        StatusCode::FORBIDDEN => return Err(ApiError::NotFound), // Oddly this is the not-found code
+        StatusCode::FORBIDDEN => return Err(ApiError::NotFound),
         StatusCode::NOT_FOUND => return Err(ApiError::NotFound),
         status => {
             return Err(ApiError::unexpected_response(status, body));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,7 @@ pub fn get_package_response(
     match parts.status {
         StatusCode::OK => (),
         StatusCode::FORBIDDEN => return Err(ApiError::NotFound), // Oddly this is the not-found code
+        StatusCode::NOT_FOUND => return Err(ApiError::NotFound),
         status => {
             return Err(ApiError::unexpected_response(status, body));
         }
@@ -341,6 +342,7 @@ pub fn get_package_tarball_response(
     match parts.status {
         StatusCode::OK => (),
         StatusCode::FORBIDDEN => return Err(ApiError::NotFound),
+        StatusCode::NOT_FOUND => return Err(ApiError::NotFound),
         status => {
             return Err(ApiError::unexpected_response(status, body));
         }


### PR DESCRIPTION
Currently, the `get_package_response` and `get_package_tarball_response` functions return `UnexpectedResponse` instead of `NotFound`.