### PR TITLE
use regex from hexpm to validate package name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -737,7 +737,7 @@ static USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), " (", env!("CARGO_PKG_
 
 fn validate_package_and_version(package: &str, version: &str) -> Result<(), ApiError> {
     lazy_static! {
-        static ref PACKAGE_PATTERN: Regex = Regex::new(r#"^[a-z_-]+$"#).unwrap();
+        static ref PACKAGE_PATTERN: Regex = Regex::new(r#"^[a-z]\w*$"#).unwrap();
         static ref VERSION_PATTERN: Regex = Regex::new(r#"^[a-zA-Z-0-9\._-]+$"#).unwrap();
     }
     if !PACKAGE_PATTERN.is_match(package) {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -402,7 +402,7 @@ async fn remove_docs_bad_package_name() {
 #[tokio::test]
 async fn publish_docs_success() {
     let key = "my-api-key-here";
-    let package = "gleam_experimental_stdlib";
+    let package = "gleam_experimental_stdlib_123";
     let version = "0.8.0";
     let tarball = std::include_bytes!("../test/example.tar.gz").to_vec();
 


### PR DESCRIPTION
updates the regex to the one I found here
https://github.com/hexpm/hexpm/blob/d6bfdb1ecae7f05b826b252be2e53f6a59da7a38/lib/hexpm/repository/package.ex#L60

this should fix gleam-lang/gleam#2384 once it filters its way through