### PR TITLE
Bump mockito to 0.31.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ base16 = { version = "0.2", features = ["alloc"] }
 # HTTP client
 reqwest = { version = "0.12", features = ["json"] }
 # HTTP mock server
-mockito = "0.30"
+mockito = "0.31.1"
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 # toml encoding


### PR DESCRIPTION
Fixes a RUSTSEC advisory where mockito was depending on an unmaintained crate
https://github.com/lipanski/mockito/pull/145