### PR TITLE
Added caret versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Added caret versions which allow only semver compatible updates
+  (aka updates which do not change the leftmost non-zero version number in major.minor.patch)
+  See: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html?highlight=caret#specifying-dependencies-from-cratesio
+
 ## v2.2.0 - 2024-04-10
 
 - Updated for latest version of Reqwest.

--- a/src/version/lexer.rs
+++ b/src/version/lexer.rs
@@ -50,6 +50,8 @@ pub enum Token<'input> {
     GtEq,
     /// '~>`
     Pessimistic,
+    /// '^'
+    Caret,
     /// `.`
     Dot,
     /// `-`
@@ -91,6 +93,7 @@ impl<'input> std::fmt::Display for Token<'input> {
             LtEq => write!(f, "<="),
             GtEq => write!(f, "<="),
             Pessimistic => write!(f, "~>"),
+            Caret => write!(f, "^"),
             Dot => write!(f, "."),
             Hyphen => write!(f, "-"),
             Plus => write!(f, "+"),
@@ -240,6 +243,7 @@ impl<'input> Iterator for Lexer<'input> {
                     }
                     '>' => Gt,
                     '<' => Lt,
+                    '^' => Caret,
                     '.' => Dot,
                     '-' => Hyphen,
                     '+' => Plus,
@@ -270,7 +274,7 @@ mod tests {
     #[test]
     pub fn simple_tokens() {
         assert_eq!(
-            lex("!===><<=>=~>.-+orand"),
+            lex("!===><<=>=~>^.-+orand"),
             vec![
                 NotEq,
                 Eq,
@@ -279,6 +283,7 @@ mod tests {
                 LtEq,
                 GtEq,
                 Pessimistic,
+                Caret,
                 Dot,
                 Hyphen,
                 Plus,

--- a/src/version/tests.rs
+++ b/src/version/tests.rs
@@ -318,6 +318,66 @@ parse_range_test!(
         )
 );
 
+parse_range_test!(
+    caret_only_major,
+    "^4",
+    PubgrubRange::higher_than(v(4, 0, 0))
+        .intersection(&PubgrubRange::strictly_lower_than(v(5, 0, 0)))
+);
+
+parse_range_test!(
+    caret_nonzero_major,
+    "^4.6.5",
+    PubgrubRange::higher_than(v(4, 6, 5))
+        .intersection(&PubgrubRange::strictly_lower_than(v(5, 0, 0)))
+);
+
+parse_range_test!(
+    caret_nonzero_minor,
+    "^0.6.5",
+    PubgrubRange::higher_than(v(0, 6, 5))
+        .intersection(&PubgrubRange::strictly_lower_than(v(0, 7, 0)))
+);
+
+parse_range_test!(
+    caret_zero_major_zero_minor,
+    "^0.0.5",
+    PubgrubRange::exact(v(0, 0, 5))
+);
+
+parse_range_test!(
+    caret_nonzero_major_pre,
+    "^4.6.5-eee",
+    PubgrubRange::higher_than(v_(
+        4,
+        6,
+        5,
+        vec![Identifier::AlphaNumeric("eee".to_string())],
+        None,
+    ))
+    .intersection(&PubgrubRange::strictly_lower_than(v(5, 0, 0)))
+);
+
+parse_range_test!(
+    greater_or_caret,
+    "> 10.0.0 or ^ 3.0.0",
+    PubgrubRange::higher_than(v(10, 0, 1)).union(
+        &PubgrubRange::higher_than(v(3, 0, 0))
+            .intersection(&PubgrubRange::strictly_lower_than(v(4, 0, 0)))
+    )
+);
+
+parse_range_test!(
+    caret_or_caret,
+    "^ 0.1.0 or ^3.0.0",
+    PubgrubRange::higher_than(v(0, 1, 0))
+        .intersection(&PubgrubRange::strictly_lower_than(v(0, 2, 0)))
+        .union(
+            &PubgrubRange::higher_than(v(3, 0, 0))
+                .intersection(&PubgrubRange::strictly_lower_than(v(4, 0, 0)))
+        )
+);
+
 parse_range_fail_test!(range_quad, "1.1.1.1");
 parse_range_fail_test!(range_just_major, "1");
 parse_range_fail_test!(range_just_major_minor, "1.1");


### PR DESCRIPTION
Added caret versions which allow only semver compatible updates.
Which are updates which do not change the leftmost non-zero version number in major.minor.patch.

See: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html?highlight=caret#specifying-dependencies-from-cratesio
Corresponding issue: https://github.com/gleam-lang/gleam/issues/2976