### PR TITLE
Add APIs for changing package owners and rename revert_package to remove_owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- Added `add_owner_request`, `add_owner_response`
+  `transfer_owner_request`, `transfer_owner_response`
+
+- `revert_package_request`, and `revert_package_response`
+  are renamed to `remove_package_request`, and `remove_package_response`
+  to accurately describe what they actuallly do
+
 ## v2.4.1 - 2025-05-01
 
 - Fixed a bug where prerelease versions would not `bump` correctly. This caused


### PR DESCRIPTION
It turns out that revert_package_request was actually for removing owners. I have tried to mitigate these mistakes in the future by making documentation over at #28 which has a somewhat reliable process for figuring out how the API works.

Part of https://github.com/gleam-lang/gleam/issues/3155