### PR TITLE
Fix PubGrub's `bump` to be strictly higher for pre-releases

### DIFF
--- a/src/version/tests.rs
+++ b/src/version/tests.rs
@@ -3,6 +3,8 @@ use std::{
     collections::HashMap,
 };
 
+use pubgrub::version::Version as _;
+
 use crate::{ApiError, Release, RetirementReason, RetirementStatus};
 
 use super::{
@@ -388,6 +390,30 @@ assert_order!(ord_pre_smaller_than_zero, "1.0.0", Greater, "1.0.0-rc1");
 assert_order!(ord_pre_smaller_than_zero_flip, "1.0.0-rc1", Less, "1.0.0");
 
 assert_order!(ord_pre_rc1_2, "1.0.0-rc1", Less, "1.0.0-rc2");
+
+#[test]
+fn test_pubgrub_bump_patch() {
+    assert_eq!(
+        Version::parse("1.0.0").unwrap().bump(),
+        Version::parse("1.0.1").unwrap()
+    );
+}
+
+#[test]
+fn test_pubgrub_bump_prerelease_ending_with_a_number() {
+    assert_eq!(
+        Version::parse("1.0.0-rc2").unwrap().bump(),
+        Version::parse("1.0.0-rc3").unwrap()
+    );
+}
+
+#[test]
+fn test_pubgrub_bump_prerelease_ending_with_a_letter() {
+    assert_eq!(
+        Version::parse("1.0.0-rc2a").unwrap().bump(),
+        Version::parse("1.0.0-rc2a1").unwrap()
+    );
+}
 
 struct Remote {
     deps: HashMap<String, Package>,


### PR DESCRIPTION
This PR fixes the implementation of PubGrub's `bump` method to satisfy the requirement of being the "smallest strictly higher version".

This change is motivated by the investigation done in https://github.com/pubgrub-rs/pubgrub/issues/222, which concluded that:

> The problem turned out to be your implementation of `pubgrub::version::Version::bump` which needs to be "the smallest strictly higher version". So when we're dealing with prereleases of the same version:

Previously the `bump` implementation would always bump the patch release.

This meant for pre-releases (e.g., `1.0.0-rc2`) the bump would result in `1.0.1-rc2` instead of `1.0.0-rc3`.

Now the `bump` implementation will do the following for versions containing pre-releases:

- The last pre-release component will be bumped.
- If the last pre-release component is strictly numeric, it will be incremented by 1.
- If the last pre-release component is alphanumeric:
  - If the trailing segment of the component is numeric, it will be incremented by 1.
    - Example: `rc1` -> `rc2`, `alpha5` -> `alpha6`
  - If the trailing segment of the component is alphabetic, if will have `1` appended to it.
    - Example: `rc2a` -> `rc2a1`, `alpha` -> `alpha1`

Additionally, I built a copy of the Gleam compiler using a version of `hexpm` that contained the changes in this PR and observed that it resolved the compiler panic mentioned in https://github.com/gleam-lang/gleam/issues/3201.