### PR TITLE
Bump pubgrub version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ ring = "0.17"
 # PEM -> DER conversion
 x509-parser = "0.15"
 # Pubgrub dependency resolution algorithm
-pubgrub = "0.2"
+pubgrub = "0.3"
 # Basic auth HTTP helper
 http-auth-basic = "0.3"
 # base16 encoding

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -790,7 +790,8 @@ fn proto_to_retirement_reason(reason: proto::package::RetirementReason) -> Retir
 fn proto_to_dep(dep: proto::package::Dependency) -> Result<(String, Dependency), ApiError> {
     let app = dep.app;
     let repository = dep.repository;
-    let requirement = Range::new(dep.requirement);
+    let requirement = Range::new(dep.requirement.clone())
+        .map_err(|_| ApiError::InvalidVersionFormat(dep.requirement))?;
     Ok((
         dep.package,
         Dependency {
@@ -941,7 +942,8 @@ impl Dependency {
             app: None,
             optional: false,
             repository: None,
-            requirement: Range::new(version.to_string()),
+            requirement: Range::new(version.to_string())
+                .expect("a version string should be a valid range string"),
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1221,7 +1221,7 @@ async fn get_package_release_ok() {
                 (
                     "plug".into(),
                     Dependency {
-                        requirement: Range::new("~>0.11.0".into()),
+                        requirement: Range::new("~>0.11.0".into()).unwrap(),
                         optional: false,
                         app: Some("plug".into()),
                         repository: None
@@ -1230,7 +1230,7 @@ async fn get_package_release_ok() {
                 (
                     "cowboy".into(),
                     Dependency {
-                        requirement: Range::new("~>1.0.0".into()),
+                        requirement: Range::new("~>1.0.0".into()).unwrap(),
                         optional: false,
                         app: Some("cowboy".into()),
                         repository: None

--- a/src/version/parser.rs
+++ b/src/version/parser.rs
@@ -5,10 +5,11 @@ use std::mem;
 
 use self::Error::*;
 use super::lexer::{self, Lexer, Token};
+use crate::version::exact;
 use crate::version::{Identifier, Version};
 use thiserror::Error;
 
-type PubgrubRange = pubgrub::range::Range<Version>;
+type PubgrubRange = pubgrub::Range<Version>;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Error)]
 pub enum Error {
@@ -322,11 +323,11 @@ impl<'input> Parser<'input> {
             self.skip_whitespace()?;
             match self.peek() {
                 None => break,
-                Some(Numeric(_)) => range = and(range, PubgrubRange::exact(self.version()?)),
+                Some(Numeric(_)) => range = and(range, exact(self.version()?)),
 
                 Some(Eq) => {
                     self.pop()?;
-                    range = and(range, PubgrubRange::exact(self.version()?));
+                    range = and(range, exact(self.version()?));
                 }
 
                 Some(NotEq) => {

--- a/src/version/tests.rs
+++ b/src/version/tests.rs
@@ -482,7 +482,7 @@ fn make_remote() -> Box<Remote> {
                             app: None,
                             optional: false,
                             repository: None,
-                            requirement: Range::new(">= 0.1.0".to_string()),
+                            requirement: Range::new(">= 0.1.0".to_string()).unwrap(),
                         },
                     )]
                     .into(),
@@ -498,7 +498,7 @@ fn make_remote() -> Box<Remote> {
                             app: None,
                             optional: false,
                             repository: None,
-                            requirement: Range::new(">= 0.1.0".to_string()),
+                            requirement: Range::new(">= 0.1.0".to_string()).unwrap(),
                         },
                     )]
                     .into(),
@@ -514,7 +514,7 @@ fn make_remote() -> Box<Remote> {
                             app: None,
                             optional: false,
                             repository: None,
-                            requirement: Range::new(">= 0.1.0".to_string()),
+                            requirement: Range::new(">= 0.1.0".to_string()).unwrap(),
                         },
                     )]
                     .into(),
@@ -560,7 +560,11 @@ fn resolution_with_locked() {
     let result = resolve_versions(
         make_remote(),
         "app".to_string(),
-        vec![("gleam_stdlib".to_string(), Range::new("~> 0.1".to_string()))].into_iter(),
+        vec![(
+            "gleam_stdlib".to_string(),
+            Range::new("~> 0.1".to_string()).unwrap(),
+        )]
+        .into_iter(),
         &vec![locked_stdlib].into_iter().collect(),
     )
     .unwrap();
@@ -589,7 +593,11 @@ fn resolution_1_dep() {
     let result = resolve_versions(
         make_remote(),
         "app".to_string(),
-        vec![("gleam_stdlib".to_string(), Range::new("~> 0.1".to_string()))].into_iter(),
+        vec![(
+            "gleam_stdlib".to_string(),
+            Range::new("~> 0.1".to_string()).unwrap(),
+        )]
+        .into_iter(),
         &vec![].into_iter().collect(),
     )
     .unwrap();
@@ -609,7 +617,11 @@ fn resolution_with_nested_deps() {
     let result = resolve_versions(
         make_remote(),
         "app".to_string(),
-        vec![("gleam_otp".to_string(), Range::new("~> 0.1".to_string()))].into_iter(),
+        vec![(
+            "gleam_otp".to_string(),
+            Range::new("~> 0.1".to_string()).unwrap(),
+        )]
+        .into_iter(),
         &vec![].into_iter().collect(),
     )
     .unwrap();
@@ -632,7 +644,11 @@ fn resolution_locked_to_older_version() {
     let result = resolve_versions(
         make_remote(),
         "app".to_string(),
-        vec![("gleam_otp".to_string(), Range::new("~> 0.1.0".to_string()))].into_iter(),
+        vec![(
+            "gleam_otp".to_string(),
+            Range::new("~> 0.1.0".to_string()).unwrap(),
+        )]
+        .into_iter(),
         &vec![].into_iter().collect(),
     )
     .unwrap();
@@ -657,7 +673,7 @@ fn resolution_retired_versions_not_used_by_default() {
         "app".to_string(),
         vec![(
             "package_with_retired".to_string(),
-            Range::new("> 0.0.0".to_string()),
+            Range::new("> 0.0.0".to_string()).unwrap(),
         )]
         .into_iter(),
         &vec![].into_iter().collect(),
@@ -682,7 +698,7 @@ fn resolution_retired_versions_can_be_used_if_locked() {
         "app".to_string(),
         vec![(
             "package_with_retired".to_string(),
-            Range::new("> 0.0.0".to_string()),
+            Range::new("> 0.0.0".to_string()).unwrap(),
         )]
         .into_iter(),
         &vec![("package_with_retired".to_string(), Version::new(0, 2, 0))]
@@ -709,7 +725,7 @@ fn resolution_prerelease_can_be_selected() {
         "app".to_string(),
         vec![(
             "gleam_otp".to_string(),
-            Range::new("~> 0.3.0-rc1".to_string()),
+            Range::new("~> 0.3.0-rc1".to_string()).unwrap(),
         )]
         .into_iter(),
         &vec![].into_iter().collect(),
@@ -737,7 +753,11 @@ fn resolution_not_found_dep() {
     resolve_versions(
         make_remote(),
         "app".to_string(),
-        vec![("unknown".to_string(), Range::new("~> 0.1".to_string()))].into_iter(),
+        vec![(
+            "unknown".to_string(),
+            Range::new("~> 0.1".to_string()).unwrap(),
+        )]
+        .into_iter(),
         &vec![].into_iter().collect(),
     )
     .unwrap_err();
@@ -750,7 +770,7 @@ fn resolution_no_matching_version() {
         "app".to_string(),
         vec![(
             "gleam_stdlib".to_string(),
-            Range::new("~> 99.0".to_string()),
+            Range::new("~> 99.0".to_string()).unwrap(),
         )]
         .into_iter(),
         &vec![].into_iter().collect(),
@@ -765,7 +785,7 @@ fn resolution_locked_version_doesnt_satisfy_requirements() {
         "app".to_string(),
         vec![(
             "gleam_stdlib".to_string(),
-            Range::new("~> 0.1.0".to_string()),
+            Range::new("~> 0.1.0".to_string()).unwrap(),
         )]
         .into_iter(),
         &vec![("gleam_stdlib".into(), Version::new(0, 2, 0))]


### PR DESCRIPTION
This bump changes the packages public API. This is mostly due to the implementation beeing a bit leaky. If you are unhappy with the changes, I can prioritize stability over ease of implementation. The major changes are mostly due to the change in the `pubgrub::DependencyProvider` trait that got overhauled pretty majorly.