### PR TITLE
Provide a way to get the underlying pubgrub range from a Range.

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -262,9 +262,16 @@ impl From<pubgrub::Range<Version>> for Range {
         Self { spec, range }
     }
 }
+
 impl From<Version> for Range {
     fn from(version: Version) -> Self {
         pubgrub::Range::singleton(version).into()
+    }
+}
+
+impl From<Range> for pubgrub::Range<Version> {
+    fn from(range: Range) -> Self {
+        range.range
     }
 }
 


### PR DESCRIPTION
This provides a way to get the underlying pubgrub range from a Range, thus makes it possible to avoid an unnecessary clone if one needs a pubgrub range (gleam does).