### PR TITLE
update deserialising to use `String` instead of `&str`

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -7,7 +7,7 @@ use std::{cmp::Ordering, convert::TryFrom, fmt};
 use self::parser::Parser;
 use serde::{
     Deserialize, Serialize,
-    de::{self, Deserializer},
+    de::{self, Deserializer, Visitor},
 };
 
 mod lexer;
@@ -153,8 +153,24 @@ impl<'de> Deserialize<'de> for Version {
     where
         D: Deserializer<'de>,
     {
-        let s: &str = Deserialize::deserialize(deserializer)?;
-        Version::try_from(s).map_err(de::Error::custom)
+        deserializer.deserialize_str(VersionVisitor)
+    }
+}
+
+struct VersionVisitor;
+
+impl<'de> Visitor<'de> for VersionVisitor {
+    type Value = Version;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a Hex version string")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Version::try_from(value).map_err(de::Error::custom)
     }
 }
 

--- a/src/version/lexer.rs
+++ b/src/version/lexer.rs
@@ -122,7 +122,7 @@ pub struct Lexer<'input> {
 
 impl<'input> Lexer<'input> {
     /// Construct a new lexer for the given input.
-    pub fn new(input: &str) -> Lexer {
+    pub fn new(input: &str) -> Lexer<'_> {
         let mut chars = input.char_indices();
         let c1 = chars.next();
         let c2 = chars.next();
@@ -263,7 +263,7 @@ impl<'input> Iterator for Lexer<'input> {
 mod tests {
     use super::*;
 
-    fn lex(input: &str) -> Vec<Token> {
+    fn lex(input: &str) -> Vec<Token<'_>> {
         Lexer::new(input).map(Result::unwrap).collect::<Vec<_>>()
     }
 


### PR DESCRIPTION
This is needed to fix https://github.com/gleam-lang/gleam/issues/4881
The newer versions of toml fail if the version string is being deserialised as `&str` instead of a `String`