### PR TITLE
Handle base URLs without trailing slash

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,16 @@ fn make_request(
     let mut parts = base.into_parts();
     parts.path_and_query = Some(
         match parts.path_and_query {
-            Some(path) => format!("{}{}", path, path_suffix).try_into(),
+            Some(path_and_query) => {
+                let mut path = path_and_query.path().to_owned();
+                if !path.ends_with('/') {
+                    path.push('/');
+                }
+                path += path_suffix;
+
+                // Drop query parameters
+                path.try_into()
+            }
             None => path_suffix.try_into(),
         }
         .expect("api_uri path"),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1342,3 +1342,17 @@ async fn get_package_release_ok() {
         }
     )
 }
+
+#[test]
+fn make_request_base_trailing_slash_is_optional() {
+    let slash = http::Uri::from_static("http://host/path/");
+    let no_slash = http::Uri::from_static("http://host/path");
+    let suffix = "suffix";
+    let expect = "/path/suffix";
+
+    let slash = make_request(slash, http::Method::GET, suffix, None);
+    assert_eq!(slash.uri_ref().unwrap().path(), expect);
+
+    let no_slash = make_request(no_slash, http::Method::GET, suffix, None);
+    assert_eq!(no_slash.uri_ref().unwrap().path(), expect);
+}


### PR DESCRIPTION
While implementing [hex mirrors](https://hex.pm/docs/mirrors) for gleam, I couldn't figure out why `https://hexpm.upyun.com` worked but `https://cdn.jsdelivr.net/hex` did not.

Turns out if the base URL has a non-empty path without a trailing slash, requests aren't constructed quite right.